### PR TITLE
Feat/zzh 20210126 optimise utree

### DIFF
--- a/src/public/@types/declares/dData/dData.Tree.d.ts
+++ b/src/public/@types/declares/dData/dData.Tree.d.ts
@@ -5,7 +5,11 @@
 declare namespace dData {
     namespace Tree {
         type Id = string | number;
-        type Base = { id: Id; pid?: Id | null };
+        // type Base = { id: Id; pid?: Id | null };
+        type Base = {
+            id: Id;
+            [key: string]: any
+        };
         type Item<T extends Base> = T & { children?: Item<T>[] };
     }
 }

--- a/src/public/utils/uTree.ts
+++ b/src/public/utils/uTree.ts
@@ -5,15 +5,18 @@
 import uObject from './uObject';
 
 export namespace uTree {
-    export const create = <TBase extends dData.Tree.Base, TId extends dData.Tree.Id>(list: TBase[], pid?: TId | null) =>
-        list.filter(value => (pid == null && value.pid == null) || pid === value.pid).map(value => {
-            const item = { ...value } as TBase & { children?: TBase[] };
-            const children = create(list, value.id);
+    export const create = <PidObj extends dData.Tree.Base, KeyObj extends dData.Tree.Base, Base extends KeyObj & PidObj>(list: Base[], pidObj: { pidKey: keyof PidObj; pid: dData.Tree.Id | null } = { pidKey: 'pid', pid: null }) => {
+        const { pidKey, pid } = pidObj;
+        return list.filter(value => (pid == null && value[pidKey] == null) || pid === value[pidKey]).map(value => {
+            console.log('value[pidKey]',value[pidKey]);
+            const item = { ...value } as Base & { children?: Base[] };
+            const children = create(list, { pidKey, pid: value.id });
             if (children.length) {
                 item.children = children;
             }
             return item;
         });
+    };
 
     type FlattenOption<TKeepChildren extends boolean | undefined> = { keepChildren?: TKeepChildren };
     const _flatten = <TBase extends dData.Tree.Base, TKeepChildren extends boolean | undefined>(


### PR DESCRIPTION
主要变更Base类型，因为tree的pidKey不定，所以key放宽为string类型

type Base = {
      id: Id;
      [key: string]: any
  };